### PR TITLE
Disallow connections if their uuid is already on the server.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -330,6 +330,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             disconnect( bungee.getTranslation( "already_connected" ) );
             return;
         }
+        
+        if ( !isOnlineMode() && bungee.getPlayer( getName() ).getUniqueId() != null )
+        {
+            disconnect( bungee.getTranslation( "already_connected" ) );
+            return;
+        }
 
         Callback<PreLoginEvent> callback = new Callback<PreLoginEvent>()
         {
@@ -417,7 +423,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     {
         // Check for multiple connections
         ProxiedPlayer old = bungee.getPlayer( getName() );
-        if ( old != null )
+        if ( old != null && old.getUniqueId() != null )
         {
             // TODO See #1218
             old.disconnect( bungee.getTranslation( "already_connected" ) );


### PR DESCRIPTION
https://github.com/SpigotMC/BungeeCord/pull/1364
This prevents players from connecting if they change their name while they are logged in, meaning they have two accounts with the same uuid. Credit to Coelho for finding this bug.